### PR TITLE
remove nan check

### DIFF
--- a/chainer_ctc/warpctc.py
+++ b/chainer_ctc/warpctc.py
@@ -76,9 +76,6 @@ class CTC(function.Function):
                 except:
                     raise e
 
-        if np.any(np.isnan(loss)):
-            raise ValueError
-
         score = xp.full((1,), xp.mean(loss), dtype=np.float32)
         return score,
 


### PR DESCRIPTION
Is it okay to remove the loss check (whether it is nan or not)?
We sometimes encounter that the loss becomes nan (not only your implementation, but others as well).
Then, with your current code, all training is stopped due to this.

In ESPnet, we actually keep this nan information, and it is handled before the parameter update (basically skip the update for this batch).
https://github.com/espnet/espnet/blob/master/src/asr/asr_chainer.py#L122

The other option might be using warning rather than removing this check.